### PR TITLE
feat: migrate Dockerfile to use Chainguard image

### DIFF
--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-05-18T10:39:34Z
+2026-05-25T10:51:01Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-05-11T10:25:07Z
+2026-05-18T10:39:34Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-03-30T09:47:27Z
+2026-04-06T09:42:27Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-07-27T10:32:33Z
+2026-08-03T10:26:49Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-07-06T10:49:45Z
+2026-07-20T10:22:42Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,0 +1,2 @@
+File for triggering automated rebuilds to pick up new base images
+2026-03-05T20:33:25Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-08-03T10:26:49Z
+2026-08-10T09:49:45Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-07-20T10:22:42Z
+2026-07-27T10:32:33Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-04-20T09:44:55Z
+2026-04-27T09:54:22Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-03-16T09:33:10Z
+2026-03-23T09:29:16Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-03-23T09:29:16Z
+2026-03-30T09:47:27Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-06-15T11:12:27Z
+2026-06-22T11:02:55Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-04-06T09:42:27Z
+2026-04-13T09:53:12Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-05-25T10:51:01Z
+2026-06-01T11:04:19Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-04-27T09:54:22Z
+2026-05-04T09:55:20Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-05-04T09:55:20Z
+2026-05-11T10:25:07Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-06-22T11:02:55Z
+2026-07-06T10:49:45Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-04-13T09:53:12Z
+2026-04-20T09:44:55Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-06-08T10:53:21Z
+2026-06-15T11:12:27Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-06-01T11:04:19Z
+2026-06-08T10:53:21Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-03-09T09:25:07Z
+2026-03-16T09:33:10Z

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,2 +1,2 @@
 File for triggering automated rebuilds to pick up new base images
-2026-03-05T20:33:25Z
+2026-03-09T09:25:07Z

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,33 @@
-FROM rust:1.45 as build_env
+FROM --platform=linux/amd64 694713800774.dkr.ecr.us-east-2.amazonaws.com/golden/rust:1.86.0-dev AS build-dev
 
-RUN apt-get update -y && apt-get install -y libssl-dev
+USER root
+RUN apk add --no-cache build-base perl linux-headers curl ca-certificates
+ARG OPENSSL_VERSION=1.1.1w
+RUN curl -sSL https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+  | tar -xz -C /tmp \
+  && cd /tmp/openssl-${OPENSSL_VERSION} \
+  && ./config no-shared --prefix=/usr/local/openssl-1.1 --openssldir=/usr/local/openssl-1.1 \
+  && make -j"$(nproc)" \
+  && make install_sw \
+  && rm -rf /tmp/openssl-${OPENSSL_VERSION}
+USER nonroot
+ENV OPENSSL_DIR=/usr/local/openssl-1.1 OPENSSL_LIB_DIR=/usr/local/openssl-1.1/lib OPENSSL_INCLUDE_DIR=/usr/local/openssl-1.1/include OPENSSL_STATIC=1
 
 WORKDIR /package-source
 
 COPY Cargo.toml Cargo.lock ./
 COPY src src/
 
+USER root
+RUN cargo update -p socket2 --precise 0.3.19 && chown -R nonroot:nonroot /package-source
+USER nonroot
 RUN cargo build --release --locked
 
-RUN find -type f
+FROM --platform=linux/amd64 694713800774.dkr.ecr.us-east-2.amazonaws.com/golden/glibc-dynamic:15.1.0 AS runtime
 
-FROM ubuntu:20.04 AS runtime
+USER 65532:65532
 
-RUN apt-get update -y && apt-get install -y openssl
+COPY --from=build-dev /package-source/target/release/volume-limiting-controller /usr/local/bin/volume-limiting-controller
+COPY --from=build-dev /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY --from=build_env /package-source/target/release/volume-limiting-controller /usr/local/bin/volume-limiting-controller
-
-CMD volume-limiting-controller
+ENTRYPOINT ["/usr/local/bin/volume-limiting-controller"]


### PR DESCRIPTION
## 🚨 **NOTICE** 🚨

This pull request was fully generated using AI.
Please only merge it after a thorough review and successful testing in the staging environment.
If any adjustments are required to ensure everything works as expected, project reviewers and developers are welcome to make the necessary changes.
Any concerns, please reach out to the security team (@fmelchior, @faelsfernandesxom).

## Summary
Migrate the main Dockerfile to use private Chainguard images hosted in AWS ECR (account 694713800774, region us-east-2), preserving current behavior and improving image security and size.

## What changed
- Switched to multi-stage build using private ECR Chainguard images:
  - Build: `694713800774.dkr.ecr.us-east-2.amazonaws.com/golden/rust:1.86.0-dev`
  - Runtime: `694713800774.dkr.ecr.us-east-2.amazonaws.com/golden/glibc-dynamic:15.1.0`
- Preserved Rust toolchain compatibility and avoided `latest` tags.
- Compiled OpenSSL 1.1.1 in the build stage to satisfy `openssl-sys` and avoid runtime package installs.
- Ensured final image runs as non-root (`USER 65532:65532`).
- Set application entrypoint to the built binary: `ENTRYPOINT ["/usr/local/bin/volume-limiting-controller"]`.
- Reduced runtime surface by copying only the built binary and CA bundle.
- Forced build for linux/amd64 to fix `socket2` arch issues and pinned `socket2` to 0.3.19 during build to resolve E0512.

## Notes
- Helm chart references `.Values.image.repository` and `.Values.image.tag`; no changes required there, but deploy values should reference the private ECR image produced by this Dockerfile.
- No CI/CD workflows detected in this repo to update.
- Validated locally:
  - Built image successfully with ECR auth.
  - Confirmed non-root user and correct entrypoint via `docker inspect`.

## Security & Best Practices
- Removed runtime package installs.
- Used Chainguard minimal runtime (`glibc-dynamic`) for smallest footprint compatible with glibc-linked binary.
- Followed Chainguard official guidance; no extra comments in Dockerfile.

## How to build
```bash
aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 694713800774.dkr.ecr.us-east-2.amazonaws.com
DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -t volume-limiting-controller:<tag> .
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker build infrastructure for improved reliability and consistency.
  * Hardened build and runtime with an explicit crypto/toolchain install and stricter user permissions.
  * Switched runtime to a more locked-down base and enforced a fixed application entrypoint.
  * Added an automated rebuild trigger marker to ensure base images are refreshed regularly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->